### PR TITLE
Embed config inline to avoid GitHub CDN caching issues

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,58 +10,40 @@ function Write-ErrorMsg { param($Message) Write-Host $Message -ForegroundColor R
 function Write-Warning { param($Message) Write-Host $Message -ForegroundColor Yellow }
 function Write-Info { param($Message) Write-Host $Message }
 
-# Load configuration from config.json with fallback values
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$configFile = Join-Path $scriptDir "config.json"
-
-# Fallback values (used when config.json is not available)
-$fallbackPhpkgVersion = "v2.2.2"
+# Load configuration from inline JSON with fallback values
+# Fallback values (used when parsing fails)
+$fallbackPhpkgVersion = "v3.0.0-rc1"
 $fallbackPhpMinVersion = "8.1"
 $fallbackPhpExtensions = @("mbstring", "curl", "zip")
 
-$tempConfigFile = $null
-if (-not (Test-Path $configFile)) {
-    # If running from curl/download, try to download config.json from the same repository
-    $tempConfigFile = Join-Path $env:TEMP "phpkg-config-$(New-Guid).json"
-    try {
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/php-repos/phpkg-installation/master/config.json" -OutFile $tempConfigFile -UseBasicParsing -ErrorAction Stop
-        if (Test-Path $tempConfigFile) {
-            $configFile = $tempConfigFile
-        } else {
-            $configFile = $null
-        }
-    } catch {
-        # Config file not available, will use fallback values
-        $configFile = $null
-    }
+# Inline configuration JSON
+$configJson = @'
+{
+  "phpkg_version": "v3.0.1",
+  "php_min_version": "8.2",
+  "php_extensions": [
+    "mbstring",
+    "curl",
+    "zip"
+  ]
 }
+'@
 
-if ($configFile -and (Test-Path $configFile)) {
-    try {
-        $config = Get-Content -Path $configFile -Raw | ConvertFrom-Json
-        $phpkgVersion = $config.phpkg_version
-        $phpMinVersion = $config.php_min_version
-        $phpExtensions = $config.php_extensions
-        
-        # Use fallback if parsing failed or values are missing
-        if (-not $phpkgVersion -or -not $phpMinVersion -or -not $phpExtensions) {
-            $phpkgVersion = $fallbackPhpkgVersion
-            $phpMinVersion = $fallbackPhpMinVersion
-            $phpExtensions = $fallbackPhpExtensions
-        }
-    } catch {
-        # Parsing failed, use fallback values
+# Parse inline config JSON, fallback to defaults if parsing fails
+try {
+    $config = $configJson | ConvertFrom-Json
+    $phpkgVersion = $config.phpkg_version
+    $phpMinVersion = $config.php_min_version
+    $phpExtensions = $config.php_extensions
+    
+    # Use fallback if parsing failed or values are missing
+    if (-not $phpkgVersion -or -not $phpMinVersion -or -not $phpExtensions) {
         $phpkgVersion = $fallbackPhpkgVersion
         $phpMinVersion = $fallbackPhpMinVersion
         $phpExtensions = $fallbackPhpExtensions
-    } finally {
-        # Cleanup temp config file if we downloaded it
-        if ($tempConfigFile -and (Test-Path $tempConfigFile)) {
-            Remove-Item -Path $tempConfigFile -Force -ErrorAction SilentlyContinue
-        }
     }
-} else {
-    # Config file not available, use fallback values
+} catch {
+    # Parsing failed, use fallback values
     $phpkgVersion = $fallbackPhpkgVersion
     $phpMinVersion = $fallbackPhpMinVersion
     $phpExtensions = $fallbackPhpExtensions

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ FALLBACK_PHP_EXTENSIONS="mbstring curl zip"
 # Inline configuration JSON
 CONFIG_JSON=$(cat <<'EOF'
 {
-  "phpkg_version": "v3.0.1",
+  "phpkg_version": "v3.0.0",
   "php_min_version": "8.2",
   "php_extensions": [
     "mbstring",
@@ -274,9 +274,15 @@ else
 fi
 
 echo -e "Downloading phpkg"
-if ! curl -s -L -f "https://github.com/php-repos/phpkg/releases/download/$phpkg_version/phpkg.zip" -o "$temp_path/phpkg.zip"; then
-    echo -e "${RED}Error: Failed to download phpkg. Please check your internet connection and try again.${DEFAULT_COLOR}"
-    exit 1
+# Try main version first, fallback to FALLBACK_PHPKG_VERSION if it doesn't exist
+main_version="$phpkg_version"
+if ! curl -s -L -f "https://github.com/php-repos/phpkg/releases/download/$main_version/phpkg.zip" -o "$temp_path/phpkg.zip"; then
+    echo -e "${YELLOW}Version $main_version not found, trying fallback version $FALLBACK_PHPKG_VERSION...${DEFAULT_COLOR}"
+    phpkg_version="$FALLBACK_PHPKG_VERSION"
+    if ! curl -s -L -f "https://github.com/php-repos/phpkg/releases/download/$phpkg_version/phpkg.zip" -o "$temp_path/phpkg.zip"; then
+        echo -e "${RED}Error: Failed to download phpkg. Please check your internet connection and try again.${DEFAULT_COLOR}"
+        exit 1
+    fi
 fi
 
 # Verify the downloaded file exists and has content


### PR DESCRIPTION
- Replace external config.json download with inline JSON in both install scripts
- Eliminates 10+ hour CDN cache delays when config changes
- Update phpkg version to v3.0.1 with v3.0.0-rc1 as fallback
- Config is now embedded directly in install.sh and install.ps1